### PR TITLE
Improve responsive layout in templates

### DIFF
--- a/templates/ai_lab.html
+++ b/templates/ai_lab.html
@@ -65,7 +65,8 @@
 .chat-container {
     background: var(--bg-secondary);
     border-radius: var(--radius-lg);
-    height: 400px;
+    height: 50vh;
+    min-height: 18rem;
     overflow-y: auto;
     padding: 1rem;
     border: 1px solid rgba(255,255,255,0.1);
@@ -110,7 +111,7 @@
     background: var(--bg-card);
     border: 1px solid rgba(255,255,255,0.1);
     border-radius: var(--radius-md);
-    max-height: 200px;
+    max-height: 50vh;
     overflow-y: auto;
     z-index: 1000;
     display: none;
@@ -189,7 +190,7 @@
                 <i data-lucide="user" class="me-2" style="width: 20px; height: 20px; color: var(--spotify-green);"></i>
                 <label for="user-select" class="form-label mb-0 fw-medium">{{ _('ai_lab.generate_for') }}:</label>
             </div>
-            <select name="user" id="user-select" class="form-select" style="max-width: 200px;" onchange="this.form.submit()">
+            <select name="user" id="user-select" class="form-select" style="max-width: 12rem;" onchange="this.form.submit()">
                 <option value="main" {% if selected_user == 'main' %}selected{% endif %}>{{ aliases.main }}</option>
                 <option value="secondary" {% if selected_user == 'secondary' %}selected{% endif %}>{{ aliases.secondary }}</option>
             </select>

--- a/templates/base.html
+++ b/templates/base.html
@@ -319,7 +319,7 @@
             border-radius: var(--radius-md);
             box-shadow: var(--shadow-lg);
             backdrop-filter: blur(10px);
-            min-width: 200px;
+            min-width: 12rem;
         }
         
         .dropdown-item {
@@ -343,8 +343,8 @@
         /* Toast Notifications */
         .toast-container {
             position: fixed;
-            top: 20px;
-            right: 20px;
+            top: 1rem;
+            right: 1rem;
             z-index: 1055;
         }
         
@@ -354,7 +354,8 @@
             border-radius: var(--radius-md);
             box-shadow: var(--shadow-lg);
             backdrop-filter: blur(10px);
-            min-width: 350px;
+            min-width: 16rem;
+            max-width: 90vw;
             margin-bottom: 0.5rem;
         }
         

--- a/templates/index.html
+++ b/templates/index.html
@@ -185,7 +185,7 @@
             </div>
         </div>
         <div class="position-relative">
-            <div class="p-3 rounded-3" style="height: 350px; overflow-y: auto; background: var(--bg-secondary); font-family: 'SF Mono', 'Monaco', 'Consolas', monospace; font-size: 0.85em; border: 1px solid rgba(255,255,255,0.1);">
+            <div class="p-3 rounded-3" style="height: 40vh; min-height: 15rem; overflow-y: auto; background: var(--bg-secondary); font-family: 'SF Mono', 'Monaco', 'Consolas', monospace; font-size: 0.85em; border: 1px solid rgba(255,255,255,0.1);">
                 <code id="log-content" class="text-light">{{ _('dashboard.logs.loading') }}</code>
             </div>
             <!-- Fade overlay for better readability -->

--- a/templates/missing_tracks.html
+++ b/templates/missing_tracks.html
@@ -293,7 +293,7 @@
                 </div>
                 
                 <!-- Playlist Info -->
-                <div class="me-3" style="min-width: 120px;">
+                <div class="me-3" style="min-width: 7.5rem;">
                     <small class="text-secondary">Da playlist:</small>
                     <div class="fw-medium" style="color: var(--text-primary); font-size: 0.85rem;">{{ track[4] }}</div>
                 </div>
@@ -656,8 +656,8 @@ $(document).ready(function() {
                           type === 'warning' ? 'alert-warning' : 'alert-info';
         
         const notification = $(`
-            <div class="alert ${alertClass} alert-dismissible fade show position-fixed" 
-                 style="top: 20px; right: 20px; z-index: 1050; min-width: 300px;">
+            <div class="alert ${alertClass} alert-dismissible fade show position-fixed"
+                 style="top: 1rem; right: 1rem; z-index: 1050; min-width: 15rem; max-width: 90vw;">
                 ${message}
                 <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
             </div>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -52,7 +52,7 @@
     border-radius: var(--radius-lg);
     padding: 1.5rem;
     margin-bottom: 1.5rem;
-    min-height: 400px;
+    min-height: 40vh;
 }
 
 .chart-container h4 {


### PR DESCRIPTION
## Summary
- tweak toast and dropdown dimensions for responsiveness
- adjust dashboard log area height
- refine missing tracks playlist info width and notification positions
- make AI Lab chat area responsive and limit dropdown width
- use viewport units for chart container minimum height

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68645ee9c9b4832989308d2c37fd9426