### PR TITLE
Improve download logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,10 +68,11 @@ def download_worker():
             break
         link, track_id = track_info
         try:
-            log.info(f"Starting download for {link} (Track ID: {track_id})")
-            download_single_track_with_streamrip(link) # Ora accetta un singolo link
-            update_track_status(track_id, 'downloaded')
-            log.info(f"Download completed for {link} (Track ID: {track_id})")
+            source = "Deezer"
+            log.info(f"Starting download from {source} for {link} (Track ID: {track_id})")
+            download_single_track_with_streamrip(link, source=source)
+            update_track_status(track_id, 'downloaded', source=source)
+            log.info(f"Download completed from {source} for {link} (Track ID: {track_id})")
         except Exception as e:
             log.error(f"Error downloading {link} (Track ID: {track_id}): {e}", exc_info=True)
         finally:
@@ -290,8 +291,8 @@ def ai_lab():
         def generate_and_download_task(plex, user_inputs, fav_id, prompt, user_key):
             log.info("PHASE 1: On-demand AI playlist generation...")
             generate_on_demand_playlist(plex, user_inputs, fav_id, prompt, user_key, include_charts_data=include_charts)
-            log.info("PHASE 2: Starting automatic download...")
-            download_attempted = run_downloader_only()
+            log.info("PHASE 2: Starting automatic download from Deezer...")
+            download_attempted = run_downloader_only(source="Deezer")
             
             if download_attempted:
                 log.info("PHASE 3: Waiting for Plex scan and track verification...")

--- a/plex_playlist_sync/sync_logic.py
+++ b/plex_playlist_sync/sync_logic.py
@@ -269,8 +269,12 @@ def force_playlist_scan_and_missing_detection():
         logger.error(f"Error during forced playlist scan: {e}", exc_info=True)
 
 
-def run_downloader_only():
-    """Reads missing tracks from DB, searches for links in parallel and starts download."""
+def run_downloader_only(source: str = "Deezer"):
+    """Reads missing tracks from DB, searches for links in parallel and starts download.
+
+    Args:
+        source: origin of the download (for logs).
+    """
     logger.info("--- Starting automatic search and download for missing tracks from DB ---")
     missing_tracks_from_db = get_missing_tracks()
     
@@ -307,13 +311,13 @@ def run_downloader_only():
         # Download each unique link and update all associated tracks
         for link, track_ids in unique_links.items():
             try:
-                logger.info(f"Starting download: {link} (for {len(track_ids)} tracks)")
-                download_single_track_with_streamrip(link)
+                logger.info(f"Starting download from {source}: {link} (for {len(track_ids)} tracks)")
+                download_single_track_with_streamrip(link, source=source)
                 
                 # Update status of all tracks associated with this link
                 for track_id in track_ids:
-                    update_track_status(track_id, 'downloaded')
-                    logger.info(f"Status updated to 'downloaded' for track ID {track_id}")
+                    update_track_status(track_id, 'downloaded', source=source)
+                    logger.info(f"Status updated to 'downloaded' from {source} for track ID {track_id}")
                     
             except Exception as e:
                 logger.error(f"Error during download of {link}: {e}")
@@ -476,7 +480,7 @@ def run_full_sync_cycle():
         logger.info(f"Found {current_missing_count} missing tracks in existing DB.")
     
     if RUN_DOWNLOADER:
-        download_attempted = run_downloader_only()
+        download_attempted = run_downloader_only(source="Deezer")
         if download_attempted:
             wait_time = int(os.getenv("PLEX_SCAN_WAIT_TIME", "300"))
             logger.info(f"Waiting {wait_time} seconds to give Plex time to index...")

--- a/plex_playlist_sync/utils/database.py
+++ b/plex_playlist_sync/utils/database.py
@@ -479,14 +479,21 @@ def get_missing_track_by_id(track_id: int) -> Optional[Dict]:
         logging.error(f"Errore nel recuperare la traccia mancante ID {track_id}: {e}")
         return None
 
-def update_track_status(track_id: int, new_status: str):
-    """Aggiorna lo stato di una traccia nel database."""
+def update_track_status(track_id: int, new_status: str, source: str | None = None):
+    """Aggiorna lo stato di una traccia nel database.
+
+    Args:
+        track_id: ID della traccia nel DB.
+        new_status: Nuovo stato da impostare.
+        source: Origine dell'azione, per i log.
+    """
     try:
         with sqlite3.connect(DB_PATH) as con:
             cur = con.cursor()
             cur.execute("UPDATE missing_tracks SET status = ? WHERE id = ?", (new_status, track_id))
             con.commit()
-        logging.info(f"Stato della traccia ID {track_id} aggiornato a '{new_status}'.")
+        suffix = f" da {source}" if source else ""
+        logging.info(f"Stato della traccia ID {track_id} aggiornato a '{new_status}'{suffix}.")
     except Exception as e:
         logging.error(f"Errore nell'aggiornare lo stato della traccia ID {track_id}: {e}")
 

--- a/plex_playlist_sync/utils/downloader.py
+++ b/plex_playlist_sync/utils/downloader.py
@@ -313,9 +313,12 @@ version = "2.0"
     except Exception as e:
         logging.error(f"❌ Errore nella creazione del file di configurazione streamrip: {e}")
 
-def download_single_track_with_streamrip(link: str):
-    """
-    Lancia streamrip per scaricare un singolo URL.
+def download_single_track_with_streamrip(link: str, source: str = "Deezer"):
+    """Lancia streamrip per scaricare un singolo URL.
+
+    Args:
+        link:  URL Deezer da scaricare.
+        source: Nome della sorgente per i log.
     """
     if not link:
         logging.info("Nessun link da scaricare fornito.")
@@ -343,7 +346,7 @@ def download_single_track_with_streamrip(link: str):
         with open(temp_links_file, "w", encoding="utf-8") as f:
             f.write(f"{cleaned_link}\n")
         
-        logging.info(f"Avvio del download con streamrip per il link: {cleaned_link}")
+        logging.info(f"Avvio del download da {source} per il link: {cleaned_link}")
         
         # Configura il path per streamrip basato sull'utente corrente
         home_dir = os.path.expanduser("~")
@@ -383,7 +386,7 @@ def download_single_track_with_streamrip(link: str):
         
         # Aggiungiamo un timeout per evitare che il processo si blocchi all'infinito
         process = subprocess.run(command, capture_output=True, text=True, check=True, encoding='utf-8', timeout=1800)
-        logging.info(f"Download di {cleaned_link} completato con successo.")
+        logging.info(f"Download di {cleaned_link} da {source} completato con successo.")
         if process.stdout:
              logging.debug(f"Output di streamrip per {cleaned_link}:\n{process.stdout}")
         if process.stderr:

--- a/plex_playlist_sync/utils/soulseek.py
+++ b/plex_playlist_sync/utils/soulseek.py
@@ -1,0 +1,12 @@
+import logging
+
+
+def download_with_soulseek(query: str, *, source: str = "Soulseek") -> None:
+    """Placeholder for Soulseek download logic.
+
+    Args:
+        query: search string for the desired track or album.
+        source: label used for logging purposes.
+    """
+    logging.info(f"Attempting download from {source} with query: {query}")
+    logging.warning("Soulseek download integration not implemented.")


### PR DESCRIPTION
## Summary
- log download source when fetching tracks
- carry source info in sync download workflow
- pass source information to the web worker
- allow future Soulseek download integration
- include optional source arg when updating DB track status

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68645edae3108329b3a3654780f3252f