### PR TITLE
Add Soulseek fallback for track downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ RUN_GEMINI_PLAYLIST_CREATION=1
 # Get your ARL from: https://github.com/nathom/streamrip/wiki/Finding-your-Deezer-ARL-Cookie
 DEEZER_ARL=
 
+# Optional: use Soulseek (slskd) as fallback downloader
+USE_SOULSEEK=0
+SLSKD_URL=http://localhost:5030
+SLSKD_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Python script, executed via Docker, to keep Plex music playlists synchronized 
 - **Multi-User Management**: Supports synchronization for multiple Plex users, each with their own playlists and configurations.
 - **Weekly AI Playlists**: Uses the **Google Gemini** API to analyze a user's taste (based on a "favorites" playlist) and generate a new personalized playlist every week.
 - **Automatic Completion**: Identifies playlist tracks that are missing from your Plex library.
-- **Automatic Download**: Uses **`streamrip`** to automatically search and download albums containing missing tracks from Deezer, effectively completing your library.
+- **Automatic Download**: Uses **`streamrip`** (and optionally **Soulseek**) to automatically grab missing tracks, completing your library.
 - **Scheduled Cleanup**: Automatically removes old playlists to keep the library organized.
 - **Background Execution**: Designed to run 24/7 in a Docker container, with customizable synchronization cycles.
 - **Fast Statistics**: Charts are generated from the favorite tracks playlist, speeding up processing even on very large libraries.
@@ -179,7 +179,11 @@ If you want to modify the code or build locally:
     
     **Note**: If neither option is configured, the application will still work but will skip automatic downloads and only show links for manual download.
 
-4.  **Verify Volume Paths**
+4.  **Optional Soulseek Integration**
+    If you run a [slskd](https://github.com/slskd/slskd) instance you can set `USE_SOULSEEK=1` and configure `SLSKD_URL`/`SLSKD_TOKEN` in `.env`.
+    Missing tracks will then be searched on Soulseek when not found on Deezer.
+
+5.  **Verify Volume Paths**
     Edit `docker-compose.yml` and update the music library path:
     ```yaml
     volumes:
@@ -303,6 +307,9 @@ This is the complete list of variables to configure in the `.env` file.
 | `RUN_DOWNLOADER`                | Set to `1` to enable automatic download of missing tracks.                                            | `1` (enabled)                                 |
 | `RUN_GEMINI_PLAYLIST_CREATION`  | Set to `1` to enable weekly AI playlist creation.                                                     | `1` (enabled)                                 |
 | `DEEZER_ARL`                    | Deezer ARL cookie for downloading tracks (optional). Leave empty to skip downloads.                  | `your_arl_cookie_here`                        |
+| `USE_SOULSEEK`                  | Enable fallback downloads via Soulseek when Deezer fails.                                            | `0` |
+| `SLSKD_URL`                     | Base URL of your slskd instance.                                                                    | `http://localhost:5030` |
+| `SLSKD_TOKEN`                   | API token for slskd (if required).                                                                  | `my_slskd_token` |
 
 ## Project Structure
 

--- a/plex_playlist_sync/sync_logic.py
+++ b/plex_playlist_sync/sync_logic.py
@@ -16,6 +16,7 @@ from .utils.deezer import deezer_playlist_sync
 from .utils.helperClasses import UserInputs, Playlist as PlexPlaylist, Track as PlexTrack
 from .utils.spotify import spotify_playlist_sync
 from .utils.downloader import download_single_track_with_streamrip, DeezerLinkFinder
+from .utils.soulseek import SoulseekClient
 from .utils.gemini_ai import configure_gemini, get_plex_favorites_by_id, generate_playlist_prompt, get_gemini_playlist_data
 from .utils.weekly_ai_manager import manage_weekly_ai_playlist
 from .utils.plex import update_or_create_plex_playlist, search_plex_track
@@ -270,7 +271,7 @@ def force_playlist_scan_and_missing_detection():
 
 
 def run_downloader_only():
-    """Reads missing tracks from DB, searches for links in parallel and starts download."""
+    """Reads missing tracks from DB and tries to download them."""
     logger.info("--- Starting automatic search and download for missing tracks from DB ---")
     missing_tracks_from_db = get_missing_tracks()
     
@@ -279,7 +280,8 @@ def run_downloader_only():
         return False
 
     logger.info(f"Found {len(missing_tracks_from_db)} missing tracks. Starting parallel link search...")
-    tracks_with_links = []  # Lista di (track_id, link) per mantenere associazione
+    tracks_with_links = []  # (track_id, link)
+    unresolved_tracks = []  # tracks without Deezer link
     
     # Use ThreadPoolExecutor to parallelize network requests
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
@@ -290,9 +292,11 @@ def run_downloader_only():
             track = future_to_track[future]
             link = future.result()
             if link:
-                track_id = track[0]  # ID della traccia dal database
+                track_id = track[0]
                 tracks_with_links.append((track_id, link))
-                logger.info(f"Link found for '{track[1]}' by '{track[2]}': {link}")
+                logger.info(f"Link found for '{track[1]}' by '{track[2]}' via Deezer: {link}")
+            else:
+                unresolved_tracks.append(track)
 
     if tracks_with_links:
         logger.info(f"Found {len(tracks_with_links)} links to download.")
@@ -307,24 +311,27 @@ def run_downloader_only():
         # Download each unique link and update all associated tracks
         for link, track_ids in unique_links.items():
             try:
-                logger.info(f"Starting download: {link} (for {len(track_ids)} tracks)")
+                logger.info(f"Starting download from Deezer: {link} (for {len(track_ids)} tracks)")
                 download_single_track_with_streamrip(link)
-                
-                # Update status of all tracks associated with this link
                 for track_id in track_ids:
                     update_track_status(track_id, 'downloaded')
                     logger.info(f"Status updated to 'downloaded' for track ID {track_id}")
-                    
             except Exception as e:
                 logger.error(f"Error during download of {link}: {e}")
-                # Mark tracks as error instead of downloaded
                 for track_id in track_ids:
                     logger.warning(f"Download failed for track ID {track_id}")
-        
-        return True
-    else:
-        logger.info("No download links found for missing tracks.")
-        return False
+
+    # Process unresolved tracks with Soulseek if enabled
+    slsk_client = SoulseekClient()
+    for track in unresolved_tracks:
+        track_id, title, artist = track[0], track[1], track[2]
+        if slsk_client.search_and_download(artist, title):
+            update_track_status(track_id, 'downloaded')
+            logger.info(f"Track '{title}' by '{artist}' sourced from Soulseek")
+        else:
+            logger.warning(f"No source found for '{title}' by '{artist}'")
+
+    return bool(tracks_with_links or unresolved_tracks)
 
 
 def rescan_and_update_missing():

--- a/plex_playlist_sync/utils/downloader.py
+++ b/plex_playlist_sync/utils/downloader.py
@@ -6,6 +6,7 @@ import subprocess
 from typing import List, Dict
 import time
 import unicodedata
+from .soulseek import SoulseekClient
 
 def clean_url(url: str) -> str:
     """
@@ -399,3 +400,20 @@ def download_single_track_with_streamrip(link: str):
         if os.path.exists(temp_links_file):
             os.remove(temp_links_file)
             logging.info(f"File temporaneo di download rimosso: {temp_links_file}")
+
+
+def download_track_with_fallback(track_info: dict) -> bool:
+    """Download track using Deezer link or Soulseek as fallback."""
+    link = DeezerLinkFinder.find_track_link(track_info)
+    if link:
+        logging.info(f"Downloading '{track_info.get('title')}' from Deezer")
+        download_single_track_with_streamrip(link)
+        return True
+
+    slsk_client = SoulseekClient()
+    if slsk_client.search_and_download(track_info.get('artist', ''), track_info.get('title', '')):
+        logging.info(f"Downloading '{track_info.get('title')}' from Soulseek")
+        return True
+
+    logging.warning(f"No source found for '{track_info.get('title')}'")
+    return False

--- a/plex_playlist_sync/utils/soulseek.py
+++ b/plex_playlist_sync/utils/soulseek.py
@@ -1,0 +1,108 @@
+import os
+import time
+import hashlib
+import logging
+import requests
+
+USE_SOULSEEK = os.getenv("USE_SOULSEEK", "0") == "1"
+SLSKD_URL = os.getenv("SLSKD_URL", "").rstrip("/")
+SLSKD_TOKEN = os.getenv("SLSKD_TOKEN", "")
+
+logger = logging.getLogger(__name__)
+
+class SoulseekClient:
+    def __init__(self):
+        self.enabled = USE_SOULSEEK and bool(SLSKD_URL)
+        self.base_url = SLSKD_URL
+        self.session = requests.Session()
+        if SLSKD_TOKEN:
+            self.session.headers.update({"Authorization": f"Bearer {SLSKD_TOKEN}"})
+
+    def _post(self, path: str, data: dict | list):
+        url = f"{self.base_url}{path}"
+        r = self.session.post(url, json=data, timeout=10)
+        r.raise_for_status()
+        return r
+
+    def _get(self, path: str):
+        url = f"{self.base_url}{path}"
+        r = self.session.get(url, timeout=10)
+        r.raise_for_status()
+        return r
+
+    def search(self, query: str) -> str | None:
+        try:
+            resp = self._post("/api/v0/searches", {"searchText": query})
+            search_id = resp.json().get("id")
+            return search_id
+        except Exception as e:
+            logger.error(f"Soulseek search failed for '{query}': {e}")
+            return None
+
+    def get_search_responses(self, search_id: str):
+        try:
+            resp = self._get(f"/api/v0/searches/{search_id}/responses")
+            return resp.json()
+        except Exception as e:
+            logger.error(f"Failed to get search results {search_id}: {e}")
+            return []
+
+    def queue_download(self, username: str, filename: str, size: int) -> bool:
+        try:
+            self._post(f"/api/v0/transfers/downloads/{username}", [{"Filename": filename, "Size": size}])
+            return True
+        except Exception as e:
+            logger.error(f"Failed to queue {filename} from {username}: {e}")
+            return False
+
+    def get_queue_position(self, username: str, filename: str) -> int | None:
+        download_id = hashlib.sha1(filename.encode("utf-8")).hexdigest()
+        try:
+            resp = self._get(f"/api/v0/transfers/downloads/{username}/{download_id}/position")
+            return resp.json()
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+        except Exception as e:
+            logger.error(f"Failed to get queue position for {filename}: {e}")
+            return None
+
+    def search_and_download(self, artist: str, title: str) -> bool:
+        if not self.enabled:
+            return False
+        query = f"{artist} - {title}"
+        search_id = self.search(query)
+        if not search_id:
+            return False
+        time.sleep(2)
+        responses = self.get_search_responses(search_id)
+        if not responses:
+            logger.info(f"No Soulseek results for '{query}'")
+            return False
+        # prefer users with free slot
+        best = None
+        for resp in responses:
+            files = resp.get("files", [])
+            if not files:
+                continue
+            if best is None or (resp.get("hasFreeUploadSlot") and resp.get("queueLength", 0) < best.get("queueLength", 9999)):
+                best = resp
+        if not best:
+            logger.info(f"No downloadable files found for '{query}'")
+            return False
+        file = best["files"][0]
+        username = best["username"]
+        if not self.queue_download(username, file["filename"], file.get("size", 0)):
+            return False
+        wait = 10
+        for _ in range(5):
+            pos = self.get_queue_position(username, file["filename"])
+            if pos is None or pos == 0:
+                logger.info(f"Download of '{file['filename']}' from {username} started")
+                return True
+            logger.info(f"Queued at position {pos} for {username}, retrying in {wait}s")
+            time.sleep(wait)
+            wait *= 2
+        logger.warning(f"Download of '{file['filename']}' from {username} still queued")
+        return True


### PR DESCRIPTION
## Summary
- add Soulseek client wrapper for slskd REST API
- allow downloader and sync logic to use Soulseek when Deezer link search fails
- log which source each track was downloaded from
- document Soulseek variables and usage
- update example environment file

## Testing
- `python -m py_compile plex_playlist_sync/utils/soulseek.py plex_playlist_sync/utils/downloader.py plex_playlist_sync/sync_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_68645eced564832991191466269f837a