### PR TITLE
Add cross-platform setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,41 @@ For easier updates:
     - Ensure `config.toml` is accessible to the container
     - Set up volume mappings for your music library
 
+## 🖥️ Cross-Platform Setup
+
+Volume paths vary by host system. After copying `.env.example` and `config.example.toml`
+to their real names, mount them so the container can read them. Both `app.py` and
+`plex_playlist_sync/sync_logic.py` look for `/app/.env`.
+
+### Linux
+```yaml
+volumes:
+  - /home/youruser/Music:/music
+  - ./config.toml:/root/.config/streamrip/config.toml
+  - ./state_data:/app/state_data
+  - ./your.env:/app/.env
+```
+
+### Windows (Docker Desktop)
+Use the Docker Desktop path style.
+```yaml
+volumes:
+  - /c/Users/YourUser/Music:/music
+  - ./config.toml:/root/.config/streamrip/config.toml
+  - ./state_data:/app/state_data
+  - ./your.env:/app/.env
+```
+
+### NAS Share
+Mount the share on the host and reference the mount point.
+```yaml
+volumes:
+  - /mnt/nas/Music:/music
+  - ./config.toml:/root/.config/streamrip/config.toml
+  - ./state_data:/app/state_data
+  - ./your.env:/app/.env
+```
+
 ### ▶️ Execution
 
 #### Docker Compose (Command Line)


### PR DESCRIPTION
## Summary
- add a new Cross-Platform Setup section to describe Linux, Windows and NAS volume paths
- clarify that app.py and sync_logic.py read `/app/.env` inside the container

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68658f0b4ccc8329be4adec2b13fce06