### PR TITLE
Add debug logging for library name

### DIFF
--- a/plex_playlist_sync/sync_logic.py
+++ b/plex_playlist_sync/sync_logic.py
@@ -36,6 +36,7 @@ def build_library_index(app_state: Dict):
     logger.info("=== STARTING PARALLEL PLEX LIBRARY INDEXING ===")
     plex_url, plex_token = os.getenv("PLEX_URL"), os.getenv("PLEX_TOKEN")
     library_name = os.getenv("LIBRARY_NAME", "Musica")
+    logger.debug(f"Using library name: {library_name}")
 
     if not (plex_url and plex_token):
         logger.error("❌ Plex URL or Token not configured. Cannot index.")
@@ -337,7 +338,9 @@ def rescan_and_update_missing():
 
     try:
         plex = PlexServer(plex_url, plex_token)
-        music_library = plex.library.section(os.getenv("LIBRARY_NAME", "Musica"))
+        library_name = os.getenv("LIBRARY_NAME", "Musica")
+        logger.debug(f"Using library name: {library_name}")
+        music_library = plex.library.section(library_name)
         
         logger.info("Searching for recently added tracks to Plex to update index...")
         recently_added = music_library.search(sort="addedAt:desc", limit=500)
@@ -383,7 +386,9 @@ def run_cleanup_only():
             try:
                 plex = PlexServer(os.getenv("PLEX_URL"), token)
                 logger.info(f"--- Starting cleanup of old playlists for user {token[:4]}... ---")
-                delete_old_playlists(plex, os.getenv("LIBRARY_NAME"), int(os.getenv("WEEKS_LIMIT")), os.getenv("PRESERVE_TAG"))
+                library_name = os.getenv("LIBRARY_NAME", "Musica")
+                logger.debug(f"Using library name: {library_name}")
+                delete_old_playlists(plex, library_name, int(os.getenv("WEEKS_LIMIT")), os.getenv("PRESERVE_TAG"))
             except Exception as e:
                 logger.error(f"Error during Plex connection for cleanup (user {token[:4]}...): {e}")
 

--- a/plex_playlist_sync/utils/database.py
+++ b/plex_playlist_sync/utils/database.py
@@ -1020,6 +1020,7 @@ def diagnose_indexing_issues():
         plex_url = os.getenv("PLEX_URL")
         plex_token = os.getenv("PLEX_TOKEN")
         library_name = os.getenv("LIBRARY_NAME", "Musica")
+        logging.debug(f"Using library name: {library_name}")
         
         if not (plex_url and plex_token):
             logging.error("Credenziali Plex non configurate per diagnosi")


### PR DESCRIPTION
## Summary
- log the library name when loading `LIBRARY_NAME` from env
- apply the same log in cleanup and post-download scan
- add debug log in database diagnostics helper

## Testing
- `python -m py_compile plex_playlist_sync/sync_logic.py plex_playlist_sync/utils/database.py`

------
https://chatgpt.com/codex/tasks/task_e_686589a3aa10832983da584f7303226e