### PR TITLE
Fix Spotify sync client creation

### DIFF
--- a/plex_playlist_sync/sync_logic.py
+++ b/plex_playlist_sync/sync_logic.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 
 from plexapi.server import PlexServer
 from dotenv import load_dotenv
+from spotipy.oauth2 import SpotifyClientCredentials
+import spotipy
 
 logger = logging.getLogger(__name__)
 
@@ -163,12 +165,22 @@ def build_library_index(app_state: Dict):
 
 def sync_playlists_for_user(plex: PlexServer, user_inputs: UserInputs):
     """Performs Spotify and Deezer synchronization for a single user."""
-    if not (os.getenv("SKIP_SPOTIFY_SYNC", "0") == "1"):
-        logger.info(f"--- Starting Spotify sync for user {user_inputs.plex_token[:4]}... ---")
-        spotify_playlist_sync(plex, user_inputs)
+    if os.getenv("SKIP_SPOTIFY_SYNC", "0") != "1":
+        sp = spotipy.Spotify(
+            auth_manager=SpotifyClientCredentials(
+                client_id=user_inputs.spotipy_client_id,
+                client_secret=user_inputs.spotipy_client_secret,
+            )
+        )
+        logger.info(
+            f"--- Starting Spotify sync for user {user_inputs.plex_token[:4]}... ---"
+        )
+        spotify_playlist_sync(sp, plex, user_inputs)
     
-    if not (os.getenv("SKIP_DEEZER_SYNC", "0") == "1"):
-        logger.info(f"--- Starting Deezer sync for user {user_inputs.plex_token[:4]}... ---")
+    if os.getenv("SKIP_DEEZER_SYNC", "0") != "1":
+        logger.info(
+            f"--- Starting Deezer sync for user {user_inputs.plex_token[:4]}... ---"
+        )
         deezer_playlist_sync(plex, user_inputs)
 
 def force_playlist_scan_and_missing_detection():


### PR DESCRIPTION
## Summary
- instantiate a Spotify client in `sync_playlists_for_user`
- pass Spotify client to `spotify_playlist_sync`

## Testing
- `python -m py_compile plex_playlist_sync/sync_logic.py plex_playlist_sync/utils/spotify.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865899f27188329abc7f87f5bbcb305