### PR TITLE
Add SPOTIFY_USER_ID checks

### DIFF
--- a/plex_playlist_sync/sync_logic.py
+++ b/plex_playlist_sync/sync_logic.py
@@ -168,16 +168,19 @@ def build_library_index(app_state: Dict):
 def sync_playlists_for_user(plex: PlexServer, user_inputs: UserInputs):
     """Performs Spotify and Deezer synchronization for a single user."""
     if os.getenv("SKIP_SPOTIFY_SYNC", "0") != "1":
-        sp = spotipy.Spotify(
-            auth_manager=SpotifyClientCredentials(
-                client_id=user_inputs.spotipy_client_id,
-                client_secret=user_inputs.spotipy_client_secret,
+        if not user_inputs.spotify_user_id:
+            logger.error("SPOTIFY_USER_ID not configured; skipping Spotify sync")
+        else:
+            sp = spotipy.Spotify(
+                auth_manager=SpotifyClientCredentials(
+                    client_id=user_inputs.spotipy_client_id,
+                    client_secret=user_inputs.spotipy_client_secret,
+                )
             )
-        )
-        logger.info(
-            f"--- Starting Spotify sync for user {user_inputs.plex_token[:4]}... ---"
-        )
-        spotify_playlist_sync(sp, plex, user_inputs)
+            logger.info(
+                f"--- Starting Spotify sync for user {user_inputs.plex_token[:4]}... ---"
+            )
+            spotify_playlist_sync(sp, plex, user_inputs)
     
     if os.getenv("SKIP_DEEZER_SYNC", "0") != "1":
         logger.info(

--- a/plex_playlist_sync/utils/spotify.py
+++ b/plex_playlist_sync/utils/spotify.py
@@ -79,6 +79,9 @@ def spotify_playlist_sync(
     sp: spotipy.Spotify, plex: PlexServer, userInputs: UserInputs
 ) -> None:
     """Create/Update plex playlists with playlists from spotify."""
+    if not userInputs.spotify_user_id:
+        logging.error("SPOTIFY_USER_ID not configured; skipping Spotify sync")
+        return
     # Passa userInputs alla funzione sottostante per applicare il limite
     playlists = _get_sp_user_playlists(
         sp,


### PR DESCRIPTION
## Summary
- ensure Spotify sync is skipped when SPOTIFY_USER_ID is missing
- avoid creating Spotify client when user ID is undefined

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ee4e0e308329b7795a1c4534cb35